### PR TITLE
Develop download info

### DIFF
--- a/adminpages/debug-my-site-info-page.php
+++ b/adminpages/debug-my-site-info-page.php
@@ -1,6 +1,6 @@
 <?php
 defined( 'ABSPATH' ) || exit;
-include plugin_dir_path( plugin_dir_path( __FILE__ ) ).'classes/debug-my-site-core.php';
+include DEBUG_MY_SITE_PLUGIN_DIR_PATH . 'classes/debug-my-site-core.php';
 ?>
 
 <h1><?php _e( 'Debug My Site' , 'debug-my-site'); ?></h1><br>
@@ -12,7 +12,7 @@ include plugin_dir_path( plugin_dir_path( __FILE__ ) ).'classes/debug-my-site-co
 <div id="debug-my-site-long"><?php echo Debug_My_Site_Core::debug_info(); ?></div>
 
 <h2><?php _e( 'Download site info', 'debug-my-site' ); ?></h2>
-<div id="debug-my-site-download"><a href="">Download</a></div>
+<div id="debug-my-site-download"><a href="<?php echo Debug_My_Site_Core::build_download_url(); ?>">Download</a></div>
 
 
 

--- a/adminpages/debug-my-site-info-page.php
+++ b/adminpages/debug-my-site-info-page.php
@@ -1,5 +1,5 @@
 <?php
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 include plugin_dir_path( plugin_dir_path( __FILE__ ) ).'classes/debug-my-site-core.php';
 ?>
 
@@ -10,6 +10,9 @@ include plugin_dir_path( plugin_dir_path( __FILE__ ) ).'classes/debug-my-site-co
 <hr id="debug-my-site-hr"><br>
 <h2><?php _e( 'Debug Information', 'debug-my-site' ); ?></h2>
 <div id="debug-my-site-long"><?php echo Debug_My_Site_Core::debug_info(); ?></div>
+
+<h2><?php _e( 'Download site info', 'debug-my-site' ); ?></h2>
+<div id="debug-my-site-download"><a href="">Download</a></div>
 
 
 

--- a/classes/debug-my-site-core.php
+++ b/classes/debug-my-site-core.php
@@ -4,9 +4,9 @@
 *  Code used and altered from Caldera Forms (www.calderaforms.com) - Thanks Josh! (https://profiles.wordpress.org/shelob9/)
 */
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
-class Debug_My_Site_Core{
+class Debug_My_Site_Core {
 
 	/**
 	 * Return an array of plugin names and versions
@@ -17,11 +17,11 @@ class Debug_My_Site_Core{
 	 */
 	public static function get_plugins() {
 		$plugins     = array();
-		include_once ABSPATH  . '/wp-admin/includes/plugin.php';
+		include_once ABSPATH . '/wp-admin/includes/plugin.php';
 		$all_plugins = get_plugins();
 		foreach ( $all_plugins as $plugin_file => $plugin_data ) {
 			if ( is_plugin_active( $plugin_file ) ) {
-				$plugins[ $plugin_data[ 'Name' ] ] = $plugin_data[ 'Version' ];
+				$plugins[ $plugin_data['Name'] ] = $plugin_data['Version'];
 			}
 		}
 
@@ -65,8 +65,8 @@ class Debug_My_Site_Core{
 			'PHP Version'                 => $php,
 			'MySQL Version'               => $mysql,
 			'JQuery Version'			  => $wp_scripts->registered['jquery']->ver,
-			'Server Software'             => $_SERVER[ 'SERVER_SOFTWARE' ],
-			'Your User Agent'             => $_SERVER[ 'HTTP_USER_AGENT' ],
+			'Server Software'             => $_SERVER['SERVER_SOFTWARE'],
+			'Your User Agent'             => $_SERVER['HTTP_USER_AGENT'],
 			'Session Save Path'           => session_save_path(),
 			'Session Save Path Exists'    => ( file_exists( session_save_path() ) ? 'Yes' : 'No' ),
 			'Session Save Path Writeable' => ( is_writable( session_save_path() ) ? 'Yes' : 'No' ),
@@ -78,7 +78,7 @@ class Debug_My_Site_Core{
 			'WP Memory Limit'             => WP_MEMORY_LIMIT,
 			'Currently Active Theme'      => $theme_name . ': ' . $theme_version,
 			'Parent Theme'				  => $theme->template,
-			'Currently Active Plugins'    => $plugins
+			'Currently Active Plugins'    => $plugins,
 		);
 		if ( $html ) {
 			$debug = '';
@@ -98,20 +98,18 @@ class Debug_My_Site_Core{
 		} else {
 			return $versions;
 		}
-
-		
 	}
 
-	public static function short_debug_info( $html = true ){
+	public static function short_debug_info( $html = true ) {
 		global $wp_version, $wpdb;
 
 		$data = array(
 			'WordPress Version'     => $wp_version,
 			'PHP Version'           => phpversion(),
 			'MySQL Version'         => $wpdb->db_version(),
-			'WP_DEBUG'              => WP_DEBUG
+			'WP_DEBUG'              => WP_DEBUG,
 		);
-		if( $html ){
+		if ( $html ) {
 			$html = '';
 			foreach ( $data as $what_v => $v ) {
 				$html .= '<li style="display: inline;"><strong>' . $what_v . '</strong>: ' . $v . ' </li>';
@@ -122,4 +120,3 @@ class Debug_My_Site_Core{
 	}
 
 }
-	

--- a/classes/debug-my-site-core.php
+++ b/classes/debug-my-site-core.php
@@ -39,7 +39,7 @@ class Debug_My_Site_Core{
 	 * @return string
 	 */
 	public static function debug_info( $html = true ) {
-		global $wp_version, $wpdb;
+		global $wp_version, $wpdb, $wp_scripts;
 		$wp          = $wp_version;
 		$php         = phpversion();
 		$mysql       = $wpdb->db_version();
@@ -64,6 +64,7 @@ class Debug_My_Site_Core{
 			'WordPress Version'           => $wp,
 			'PHP Version'                 => $php,
 			'MySQL Version'               => $mysql,
+			'JQuery Version'			  => $wp_scripts->registered['jquery']->ver,
 			'Server Software'             => $_SERVER[ 'SERVER_SOFTWARE' ],
 			'Your User Agent'             => $_SERVER[ 'HTTP_USER_AGENT' ],
 			'Session Save Path'           => session_save_path(),
@@ -93,11 +94,12 @@ class Debug_My_Site_Core{
 					$debug .= $version . '</p>';
 				}
 			}
-
 			return $debug;
 		} else {
 			return $versions;
 		}
+
+		
 	}
 
 	public static function short_debug_info( $html = true ){

--- a/classes/debug-my-site-core.php
+++ b/classes/debug-my-site-core.php
@@ -116,7 +116,13 @@ class Debug_My_Site_Core {
 			}
 
 			return '<ul>' . $html . '</ul>';
+		} else {
+			return $data;
 		}
+	}
+
+	public static function build_download_url() {
+		return add_query_arg( 'download', 'true', admin_url( 'tools.php?page=debug-my-site-info' ) );
 	}
 
 }

--- a/debug-my-site.php
+++ b/debug-my-site.php
@@ -3,7 +3,7 @@
 * Plugin Name: Debug My Site
 * Plugin URI: https://yoohooplugins.com
 * Description: Get debug information for your WordPress website.
-* Version: 1.0.1
+* Version: 1.0.2
 * Author: YooHoo Plugins
 * Author URI: https://yoohooplugins.com
 * Text Domain: debug-my-site
@@ -20,6 +20,14 @@
 *
 * You should have received a copy of the GNU General Public License
 * along with Debug My Site. If not, see https://www.gnu.org/licenses/gpl-2.0.html.
+*
+* CHANGE LOG
+*
+* 1.0.2 - 28/03/2017
+* Enhancement: include JQuery version in debug information. (Works only with default JQuery that is loaded from WordPress)
+*
+* 1.0.1 - 28/03/2017
+* Minor bug fix regarding undefined constant
 */
 defined( 'ABSPATH' ) or exit;
 

--- a/debug-my-site.php
+++ b/debug-my-site.php
@@ -29,7 +29,9 @@
 * 1.0.1 - 28/03/2017
 * Minor bug fix regarding undefined constant
 */
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
+
+define( 'DEBUG_MY_SITE_PLUGIN_DIR_PATH', plugin_dir_path( __FILE__ ) );
 
 class Debug_My_Site{
 
@@ -37,6 +39,7 @@ class Debug_My_Site{
 
 	public function __construct(){
 
+		add_action( 'admin_init', array( $this, 'download_debug_info' ) );
 		add_action( 'admin_menu', array( $this, 'debug_my_site_add_page' ) );
 
 	}
@@ -44,7 +47,7 @@ class Debug_My_Site{
 	public static function get_instance() {
 
 		if ( null == self::$instance ) {
-		    self::$instance = new self;
+			self::$instance = new self;
 		}
 
 	return self::$instance;
@@ -54,6 +57,37 @@ class Debug_My_Site{
 	/**
 	* General functions go below
 	*/
+
+	public static function download_debug_info() {
+		$download = filter_input( INPUT_GET, 'download', FILTER_SANITIZE_STRING );
+		if ( ! empty( $download ) && 'true' == $download ) {
+			include_once DEBUG_MY_SITE_PLUGIN_DIR_PATH . 'classes/debug-my-site-core.php';
+			$eol = "\r\n";
+			$info = esc_attr( 'Short Debug Information', 'debug-my-site' ) . $eol;
+			$info_data = Debug_My_Site_Core::short_debug_info( false );
+			foreach ( $info_data as $key => $value ) {
+				$info .= $key . ': ' . $value . $eol;
+			}
+			$info .= $eol;
+			$info .= esc_attr( 'Debug Information', 'debug-my-site' ) . "\r\n";
+			$versions = Debug_My_Site_Core::debug_info( false );
+			foreach ( $versions as $what => $version ) {
+				$info .= $what . ': ';
+				if ( is_array( $version ) ) {
+					$info .= $eol;
+					foreach ( $version as $what_v => $v ) {
+						$info .= ' * ' . $what_v . ': ' . $v . $eol;
+					}
+				} else {
+					$info .= $version . $eol;
+				}
+			}
+			header( 'Content-type: text/plain' );
+			header( 'Content-Disposition: attachment; filename="debug_info.txt"' );
+			echo $info;
+			die();
+		}
+	}
 
 	public static function debug_my_site_add_page(){
 		add_submenu_page( 'tools.php', 'Debug My Site Information', 'Debug My Site', 'manage_options', 'debug-my-site-info', array( 'Debug_My_Site', 'debug_my_site_info_page' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -30,13 +30,24 @@ This section describes how to install the plugin and get it working.
 
 You may go to 'Tools' > 'Debug My Site' to view your WordPress environment debug information.
 
-
 == Changelog ==
 
-= 1.0 =
+= 1.0.2 =
+* Enhancement: include JQuery version number loaded by WordPress itself
+
+= 1.0.1 =
+* Minor bug fixes
+
+= 1.0.0 =
 * Initial release
 
 == Upgrade Notice ==
 
-= 1.0 =
+= 1.0.2 =
+Please update to latest version for bug fixes and enhancements
+
+= 1.0.1 =
 Initial Release
+
+= 1.0.0 =
+Minor bug fixes


### PR DESCRIPTION
Adds a 'Download Site Info' link for downloading the info and uploading to a support ticket.

Later on we might want to refactor the code functions so that the download stuff isn't duplicated, but it works for now. 